### PR TITLE
Auction mechanism change

### DIFF
--- a/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
+++ b/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
@@ -57,6 +57,9 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
     // The total amount of ETH raised in auctions
     uint256 public totalRaised;
 
+    // The total number of auctions
+    uint256 public totalAuctions;
+
     // The active auction
     INounsAuctionHouse.Auction public auction;
 
@@ -87,7 +90,6 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
         minBidIncrementPercentage = _minBidIncrementPercentage;
         duration = _duration;
         durationIncreasePercentage = _durationIncreasePercentage;
-        totalRaised = 0;
     }
 
     /**
@@ -250,6 +252,7 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
             nouns.burn(_auction.nounId);
         } else {
             nouns.transferFrom(address(this), _auction.bidder, _auction.nounId);
+            totalAuctions += 1;
         }
 
         if (_auction.amount > 0) {
@@ -257,7 +260,7 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
             totalRaised += _auction.amount;
         }
 
-        if (totalRaised / nouns.totalSupply() > _auction.amount) {
+        if (totalAuctions > 0 && totalRaised / totalAuctions > _auction.amount) {
             duration += (duration * durationIncreasePercentage) / 100;
         }
 

--- a/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
+++ b/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
@@ -51,6 +51,12 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
     // The duration of a single auction
     uint256 public duration;
 
+    // The percentage increase of an auction's duration after an auction is settled for less than the average
+    uint256 public durationIncreasePercentage;
+
+    // The total amount of ETH raised in auctions
+    uint256 public totalRaised;
+
     // The active auction
     INounsAuctionHouse.Auction public auction;
 
@@ -65,7 +71,8 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
         uint256 _timeBuffer,
         uint256 _reservePrice,
         uint8 _minBidIncrementPercentage,
-        uint256 _duration
+        uint256 _duration,
+        uint256 _durationIncreasePercentage
     ) external initializer {
         __Pausable_init();
         __ReentrancyGuard_init();
@@ -79,6 +86,8 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
         reservePrice = _reservePrice;
         minBidIncrementPercentage = _minBidIncrementPercentage;
         duration = _duration;
+        durationIncreasePercentage = _durationIncreasePercentage;
+        totalRaised = 0;
     }
 
     /**
@@ -188,6 +197,16 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
         emit AuctionMinBidIncrementPercentageUpdated(_minBidIncrementPercentage);
     }
 
+    /** 
+     * @notice Set the auction duration increase percentage.
+     * @dev Only callable by the owner.
+     */
+    function setDurationIncreasePercentage(uint256 _durationIncreasePercentage) external override onlyOwner {
+        durationIncreasePercentage = _durationIncreasePercentage;
+
+        emit AuctionDurationIncreasePercentageUpdated(_durationIncreasePercentage);
+    }
+
     /**
      * @notice Create an auction.
      * @dev Store the auction details in the `auction` state variable and emit an AuctionCreated event.
@@ -235,6 +254,11 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
 
         if (_auction.amount > 0) {
             _safeTransferETHWithFallback(owner(), _auction.amount);
+            totalRaised += _auction.amount;
+        }
+
+        if (totalRaised / nouns.totalSupply() > _auction.amount) {
+            duration += (duration * durationIncreasePercentage) / 100;
         }
 
         emit AuctionSettled(_auction.nounId, _auction.bidder, _auction.amount);

--- a/packages/nouns-contracts/contracts/interfaces/INounsAuctionHouse.sol
+++ b/packages/nouns-contracts/contracts/interfaces/INounsAuctionHouse.sol
@@ -47,6 +47,8 @@ interface INounsAuctionHouse {
 
     event AuctionMinBidIncrementPercentageUpdated(uint256 minBidIncrementPercentage);
 
+    event AuctionDurationIncreasePercentageUpdated(uint256 durationIncreasePercentage);
+
     function settleAuction() external;
 
     function settleCurrentAndCreateNewAuction() external;
@@ -62,6 +64,8 @@ interface INounsAuctionHouse {
     function setReservePrice(uint256 reservePrice) external;
 
     function setMinBidIncrementPercentage(uint8 minBidIncrementPercentage) external;
+
+    function setDurationIncreasePercentage(uint256 durationIncreasePercentage) external;
 
     function auction()
         external

--- a/packages/nouns-contracts/contracts/interfaces/INounsToken.sol
+++ b/packages/nouns-contracts/contracts/interfaces/INounsToken.sol
@@ -17,11 +17,11 @@
 
 pragma solidity ^0.8.6;
 
-import { IERC721Enumerable } from '@openzeppelin/contracts/interfaces/IERC721Enumerable.sol';
+import { IERC721 } from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 import { INounsDescriptorMinimal } from './INounsDescriptorMinimal.sol';
 import { INounsSeeder } from './INounsSeeder.sol';
 
-interface INounsToken is IERC721Enumerable {
+interface INounsToken is IERC721 {
     event NounCreated(uint256 indexed tokenId, INounsSeeder.Seed seed);
 
     event NounBurned(uint256 indexed tokenId);

--- a/packages/nouns-contracts/contracts/interfaces/INounsToken.sol
+++ b/packages/nouns-contracts/contracts/interfaces/INounsToken.sol
@@ -17,11 +17,11 @@
 
 pragma solidity ^0.8.6;
 
-import { IERC721 } from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+import { IERC721Enumerable } from '@openzeppelin/contracts/interfaces/IERC721Enumerable.sol';
 import { INounsDescriptorMinimal } from './INounsDescriptorMinimal.sol';
 import { INounsSeeder } from './INounsSeeder.sol';
 
-interface INounsToken is IERC721 {
+interface INounsToken is IERC721Enumerable {
     event NounCreated(uint256 indexed tokenId, INounsSeeder.Seed seed);
 
     event NounBurned(uint256 indexed tokenId);

--- a/packages/nouns-contracts/tasks/deploy-and-configure-short-times-dao-v3.ts
+++ b/packages/nouns-contracts/tasks/deploy-and-configure-short-times-dao-v3.ts
@@ -34,6 +34,12 @@ task(
     60 * 2 /* 2 minutes */,
     types.int,
   )
+  .addOptionalParam(
+    'auctionDurationIncreasePercentage',
+    'The auction duration increase percentage (out of 100)',
+    10 /* 10% */,
+    types.int,
+  )
   .addOptionalParam('timelockDelay', 'The timelock delay (seconds)', 60 /* 1 min */, types.int)
   .addOptionalParam(
     'votingPeriod',

--- a/packages/nouns-contracts/tasks/deploy-short-times-dao-v3.ts
+++ b/packages/nouns-contracts/tasks/deploy-short-times-dao-v3.ts
@@ -56,6 +56,12 @@ task('deploy-short-times-dao-v3', 'Deploy all Nouns contracts with short gov tim
     60 * 2 /* 2 minutes */,
     types.int,
   )
+  .addOptionalParam(
+    'auctionDurationIncreasePercentage',
+    'The auction duration increase percentage (out of 100)',
+    10 /* 10% */,
+    types.int,
+  )
   .addOptionalParam('timelockDelay', 'The timelock delay (seconds)', 60 /* 1 min */, types.int)
   .addOptionalParam(
     'votingPeriod',
@@ -182,6 +188,7 @@ task('deploy-short-times-dao-v3', 'Deploy all Nouns contracts with short gov tim
               args.auctionReservePrice,
               args.auctionMinIncrementBidPercentage,
               args.auctionDuration,
+              args.auctionDurationIncreasePercentage,
             ]),
         ],
         waitForConfirmation: true,


### PR DESCRIPTION
The goal of this change is to tweak the auction mechanism to increase the duration by 10% when an auction's settled price is below the average.

Changes:
- Implemented the mechanism in `_settleAuction()` within the `NounsAuctionHouse.sol` contract
- Added `durationIncreasePercentage`, preset to 10% in the deployment scripts
- Added a setter for `durationIncreasePercentage`