### PR TITLE
fix build issue

### DIFF
--- a/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
+++ b/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
@@ -203,7 +203,7 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
      * @notice Set the auction duration increase percentage.
      * @dev Only callable by the owner.
      */
-    function setDurationIncreasePercentage(uint256 _durationIncreasePercentage) external override onlyOwner {
+    function setDurationIncreasePercentage(uint256 _durationIncreasePercentage) external onlyOwner {
         durationIncreasePercentage = _durationIncreasePercentage;
 
         emit AuctionDurationIncreasePercentageUpdated(_durationIncreasePercentage);

--- a/packages/nouns-contracts/contracts/interfaces/INounsAuctionHouse.sol
+++ b/packages/nouns-contracts/contracts/interfaces/INounsAuctionHouse.sol
@@ -65,8 +65,6 @@ interface INounsAuctionHouse {
 
     function setMinBidIncrementPercentage(uint8 minBidIncrementPercentage) external;
 
-    function setDurationIncreasePercentage(uint256 durationIncreasePercentage) external;
-
     function auction()
         external
         view


### PR DESCRIPTION
- removed from interface because we don't really need it and other dependencies in the build break because of it
- remove `override`, since it's not in the `INounsAuctionHouse` interface any longer